### PR TITLE
Cleanup imports

### DIFF
--- a/transparent_background/InSPyReNet.py
+++ b/transparent_background/InSPyReNet.py
@@ -3,7 +3,6 @@ import sys
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-import numpy as np
 
 filepath = os.path.abspath(__file__)
 repopath = os.path.split(filepath)[0]

--- a/transparent_background/Remover.py
+++ b/transparent_background/Remover.py
@@ -18,7 +18,6 @@ import albumentations.pytorch as AP
 from PIL import Image
 from io import BytesIO
 from packaging import version
-from easydict import EasyDict
 
 filepath = os.path.abspath(__file__)
 repopath = os.path.split(filepath)[0]
@@ -266,7 +265,7 @@ def entry_point(out_type, mode, device, ckpt, source, dest, jit, threshold, flet
         _format = "Webcam"
         if importlib.util.find_spec('pyvirtualcam') is not None:
             try:
-                import pyvirtualcam
+                import pyvirtualcam # type: ignore
                 vcam = pyvirtualcam.Camera(width=640, height=480, fps=30)
             except:
                 vcam = None

--- a/transparent_background/__init__.py
+++ b/transparent_background/__init__.py
@@ -1,2 +1,0 @@
-from transparent_background.Remover import Remover, console
-from transparent_background.gui import gui

--- a/transparent_background/gui.py
+++ b/transparent_background/gui.py
@@ -3,7 +3,6 @@ from flet import (
     ElevatedButton,
     FilePicker,
     FilePickerResultEvent,
-    Page,
     Row,
     Text,
     icons,


### PR DESCRIPTION
Module auto import forces loading of `cv2` lib which causes issue in headless mode with libGL.so.1.

Since they are not needed anyway, I remove them and cleaned out other useless import.