### PR TITLE
Upgrade timm dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pip install --extra-index-url https://download.pytorch.org/whl/cu118 git+https:/
 #### Install from local
 ```bash
 git clone https://github.com/plemeri/transparent-background.git
-cd transparent-backbround
+cd transparent-background
 pip install --extra-index-url https://download.pytorch.org/whl/cu118 .
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ package | version (>=)
 `pytorch`       | `1.7.1`
 `torchvision`   | `0.8.2`
 `opencv-python` | `4.6.0.66`
-`timm`          | `0.6.11`
+`timm`          | `1.0.3`
 `tqdm`          | `4.64.1`
 `kornia`        | `0.5.4`
 `gdown`         | `4.5.4`

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "torch>=1.7.1",
         "torchvision>=0.8.2",
         "opencv-python>=4.6.0.66",
-        "timm>=0.6.11",
+        "timm>=1.0.3",
         "tqdm>=4.64.1",
         "kornia>=0.5.4",
         "gdown>=4.5.4",

--- a/transparent_background/backbones/SwinTransformer.py
+++ b/transparent_background/backbones/SwinTransformer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 import numpy as np
-from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+from timm.layers import DropPath, to_2tuple, trunc_normal_
 
 class Mlp(nn.Module):
     """ Multilayer perceptron."""


### PR DESCRIPTION
We are currently running on Python 3.12 with the following:
```
timm==1.0.15
transparent-background==1.3.2
torch==2.4.0+cpu
torchvision==0.19.0+cpu
```
and getting the following error:
```
.../python3.12/site-packages/timm/models/layers/__init__.py:48: FutureWarning: Importing from timm.models.layers is deprecated, please import via timm.layers#012  warnings.warn(f"Importing from {__name__} is deprecated, please import via timm.layers", FutureWarning)#012]
```

There didn't seem to be any adverse effects to upgrading this package, and also the new way to import. See https://pypi.org/project/timm/1.0.3/.