### PR TITLE
Estimate the foreground color using pymatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ pip install --extra-index-url https://download.pytorch.org/whl/cu118 git+https:/
 #### Install from local
 ```bash
 git clone https://github.com/plemeri/transparent-background.git
-cd transparent-backbround
+cd transparent-background
 pip install --extra-index-url https://download.pytorch.org/whl/cu118 .
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ package | version (>=)
 `pytorch`       | `1.7.1`
 `torchvision`   | `0.8.2`
 `opencv-python` | `4.6.0.66`
-`timm`          | `0.6.11`
+`timm`          | `1.0.3`
 `tqdm`          | `4.64.1`
 `kornia`        | `0.5.4`
 `gdown`         | `4.5.4`

--- a/README.md
+++ b/README.md
@@ -131,6 +131,10 @@ pip uninstall torch torchvision torchaudio
 pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cpu
 ```
 
+#### Install GPU acceleration for RGBA output
+
+When generating RGBA output, the foreground color is estimated using [`pymatting.estimate_foreground_ml`](https://pymatting.github.io/foreground.html#estimate_foreground_ml), which implements [Germer et al., 2020](https://arxiv.org/abs/2006.14970).  [pymatting](https://pymatting.github.io/)'s optional GPU acceleration requires installing [CuPy](https://docs.cupy.dev/en/stable/install.html) (if the GPU supports CUDA) or [pyopencl](https://pypi.org/project/pyopencl/). These packages are detected at runtime if available.
+
 ### [New] Configuration
 
 `transparent-background` now supports external configuration rather than hard coded assets (e.g., checkpoint download url). 
@@ -194,7 +198,7 @@ $ transparent-background --source [SOURCE] --dest [DEST] --threshold [THRESHOLD]
 * `--dest [DEST]` (optional): Specify your destination folder. Default location is current directory.
 * `--threshold [THRESHOLD]` (optional): Designate threhsold value from `0.0` to `1.0` for hard prediction. Do not use if you want soft prediction.
 * `--type [TYPE]` (optional): Choose between `rgba`, `map` `green`, `blur`, `overlay`, and another image file. Default is `rgba`.
-    * `rgba` will generate RGBA output regarding saliency score as an alpha map. Note that this will not work for video and webcam input. 
+    * `rgba` will generate RGBA output regarding saliency score as an alpha map, and perform foreground color extraction using [pymatting](https://pymatting.github.io/foreground.html) if threshold is not set. Note that this will not work for video and webcam input. 
     * `map` will output saliency map only. 
     * `green` will change the background with green screen. 
     * `white` will change the background with white color. -> [2023.05.24] Contributed by [carpedm20](https://github.com/carpedm20) 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setuptools.setup(
         # TODO: remove pin of albucore once this bug is fixed https://github.com/albumentations-team/albumentations/issues/1945
         "albucore==0.0.16",
         "flet>=0.23.1",
+        "pymatting>=1.1.13",
     ],
     extras_require={"webcam": ["pyvirtualcam>=0.6.0"]},
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setuptools.setup(
         "torch>=1.7.1",
         "torchvision>=0.8.2",
         "opencv-python>=4.6.0.66",
-        "timm>=0.6.11",
+        "timm>=1.0.3",
         "tqdm>=4.64.1",
         "kornia>=0.5.4",
         "gdown>=4.5.4",

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setuptools.setup(
         "pyyaml>=6.0",
         "albumentations>=1.3.1",
         # TODO: remove pin of albucore once this bug is fixed https://github.com/albumentations-team/albumentations/issues/1945
-        "albucore==0.0.16",
+        "albucore>=0.0.16",
         "flet>=0.23.1",
         "pymatting>=1.1.13",
     ],

--- a/transparent_background/Remover.py
+++ b/transparent_background/Remover.py
@@ -18,7 +18,7 @@ import albumentations.pytorch as AP
 from PIL import Image
 from io import BytesIO
 from packaging import version
-from easydict import EasyDict
+from pymatting import estimate_foreground_ml
 
 filepath = os.path.abspath(__file__)
 repopath = os.path.split(filepath)[0]
@@ -196,6 +196,10 @@ class Remover:
             pred = 1 - pred
 
         img = np.array(img)
+        if threshold is None:
+            img = estimate_foreground_ml(img / 255.0, pred)
+            img = 255 * np.clip(img, 0., 1.) + 0.5
+            img = img.astype(np.uint8)
 
         if type.startswith("["):
             type = [int(i) for i in type[1:-1].split(",")]

--- a/transparent_background/Remover.py
+++ b/transparent_background/Remover.py
@@ -89,7 +89,7 @@ class Remover:
         self.model = InSPyReNet_SwinB(depth=64, pretrained=False, threshold=None, **self.meta)
         self.model.eval()
         self.model.load_state_dict(
-            torch.load(os.path.join(ckpt_dir, ckpt_name), map_location="cpu"),
+            torch.load(os.path.join(ckpt_dir, ckpt_name), map_location="cpu", weights_only=True),
             strict=True,
         )
         self.model = self.model.to(self.device)

--- a/transparent_background/backbones/SwinTransformer.py
+++ b/transparent_background/backbones/SwinTransformer.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import torch.utils.checkpoint as checkpoint
 import numpy as np
-from timm.models.layers import DropPath, to_2tuple, trunc_normal_
+from timm.layers import DropPath, to_2tuple, trunc_normal_
 
 class Mlp(nn.Module):
     """ Multilayer perceptron."""


### PR DESCRIPTION
The current code creates the foreground image by concatenating the r,g,b from the input image with the alpha from the predicted matte.

However, mixed pixels, especially those at the boundary, contain a mix of the foreground and the background color. Thus, with the current code, those boundary pixels have the wrong color, see for example the top of the nose of the aeroplane, which has a dark border (please view it at full size):
![aeroplane_rgba_orig](https://github.com/user-attachments/assets/a9dcd90b-c321-4754-b6ed-1f337dc1c057)

zoomed up in macOS preview, which uses a gray background, one can clearly see the dark border:
![image](https://github.com/user-attachments/assets/08c97e25-ebb0-4a1e-b57d-115385c5a5a7)

This PR adds a call to pymatting to extract the foreground color, and here is the result:
![aeroplane_rgba_fixed](https://github.com/user-attachments/assets/4665db61-fe61-4e8d-bd6e-ba158094f3de)

zoomed up in macOS preview, which uses a gray background, the border has a better color (which is not perfect, but still better than it was before):
![image](https://github.com/user-attachments/assets/5c4bd1f6-e3cf-4bb6-9486-229087774eff)

Note: I disabled the call to pymatting when a threshold is being used, since I guess the user is expecting to extract the original colors in this case.